### PR TITLE
chore: add mergify auto-merge for renovate PRs

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -6,3 +6,21 @@ pull_request_rules:
       label:
         toggle:
           - conflict
+
+  - name: Automatic merge on approval
+    conditions:
+      - '#commits-behind=0'
+      - or:
+          - '#approved-reviews-by>=1'
+          - label=ci:auto-merge
+      - not:
+          and:
+            - 'head*=renovate/lockfile-maintenance-*'
+            - 'created-at>24h ago'
+      - base=master
+      - check-success=lint
+      - check-success=test
+      - check-success=build
+    actions:
+      merge:
+        method: squash

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,5 +4,7 @@
   "rangeStrategy": "bump",
   "lockFileMaintenance": {
     "automerge": true
-  }
+  },
+  "labels": ["ci:auto-merge", "dependencies"],
+  "prConcurrentLimit": 3
 }


### PR DESCRIPTION
Summary:
- add Mergify automatic merge rule (approval or ci:auto-merge label)
- require CI checks lint, test, and build
- add Renovate labels ci:auto-merge and dependencies
- set Renovate prConcurrentLimit to 3